### PR TITLE
Implement static assert

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -40,6 +40,8 @@ extern FOUNDATION_LIBC_NORETURN void foundation_libc_assert(char const * asserti
 #error "bad definition of FOUNDATION_LIBC_ASSERT_DEFAULT!"
 #endif
 
+#if !defined(__cplusplus)
 #define static_assert FOUNDATION_LIBC_STATIC_ASSERT
+#endif
 
 #endif

--- a/include/assert.h
+++ b/include/assert.h
@@ -40,4 +40,6 @@ extern FOUNDATION_LIBC_NORETURN void foundation_libc_assert(char const * asserti
 #error "bad definition of FOUNDATION_LIBC_ASSERT_DEFAULT!"
 #endif
 
+#define static_assert FOUNDATION_LIBC_STATIC_ASSERT
+
 #endif

--- a/include/assert.h
+++ b/include/assert.h
@@ -41,6 +41,7 @@ extern FOUNDATION_LIBC_NORETURN void foundation_libc_assert(char const * asserti
 #endif
 
 #if !defined(__cplusplus)
+#undef static_assert
 #define static_assert FOUNDATION_LIBC_STATIC_ASSERT
 #endif
 

--- a/include/foundation/builtins.h
+++ b/include/foundation/builtins.h
@@ -12,6 +12,8 @@
 #define FOUNDATION_LIBC_ASSERT FOUNDATION_LIBC_ASSERT_DEFAULT
 #endif
 
+#define FOUNDATION_LIBC_STATIC_ASSERT _Static_assert
+
 #if defined(__clang__)
 
 #define FOUNDATION_LIBC_NORETURN __attribute__((__noreturn__))

--- a/test/src/assert-validator.c
+++ b/test/src/assert-validator.c
@@ -23,3 +23,7 @@ void assert_ok(void) {
 void assert_bad(void) {
     assert(0);
 }
+
+void assert_static(void) {
+    static_assert(sizeof(int) == sizeof(int), "int size check");
+}


### PR DESCRIPTION
Static assert implementation (C11). In C++ build this is excluded as static_assert is keyword since C++11. I have no idea how tests workd in this project.